### PR TITLE
[Utils/Table] Sets ANIMATION_DURATION to 0

### DIFF
--- a/packages/dx-grid-core/src/utils/table.js
+++ b/packages/dx-grid-core/src/utils/table.js
@@ -29,8 +29,8 @@ export const getTableTargetColumnIndex = (
 ) => getTargetColumnGeometries(columnGeometries, sourceIndex)
   .findIndex(({ left, right }) => offset > left && offset < right);
 
+const ANIMATION_DURATION = 0;
 
-const ANIMATION_DURATION = 200;
 
 const getAnimationProgress = animation => (
   new Date().getTime() - animation.startTime) / ANIMATION_DURATION;


### PR DESCRIPTION
- This is to disable animations that are causing strange rendering issues on grids that have many columns and rows (and for slower older machines).